### PR TITLE
Supported more types of request parameter

### DIFF
--- a/framework/framework-netty/src/main/java/io/edurt/gcm/netty/dispatcher/ParameterDispatcher.java
+++ b/framework/framework-netty/src/main/java/io/edurt/gcm/netty/dispatcher/ParameterDispatcher.java
@@ -99,6 +99,34 @@ public class ParameterDispatcher
                                 paramList.add(Integer.valueOf(getParamValue(requestParamVal, defaultValue)));
                                 classList.add(Integer.class);
                             }
+                            else if (parameterClass == Boolean.class) {
+                                paramList.add(Boolean.valueOf(getParamValue(requestParamVal, defaultValue)));
+                                classList.add(Boolean.class);
+                            }
+                            else if (parameterClass == Float.class) {
+                                paramList.add(Float.valueOf(getParamValue(requestParamVal, defaultValue)));
+                                classList.add(Float.class);
+                            }
+                            else if (parameterClass == Double.class) {
+                                paramList.add(Double.valueOf(getParamValue(requestParamVal, defaultValue)));
+                                classList.add(Double.class);
+                            }
+                            else if (parameterClass == Short.class) {
+                                paramList.add(Short.valueOf(getParamValue(requestParamVal, defaultValue)));
+                                classList.add(Short.class);
+                            }
+                            else if (parameterClass == Character.class) {
+                                char[] chars = getParamValue(requestParamVal, defaultValue).toCharArray();
+                                Character c = null;
+                                if (chars.length == 1) {
+                                    c = Character.valueOf(chars[0]);
+                                }
+                                else {
+                                    c = (char) 0;
+                                }
+                                paramList.add(c);
+                                classList.add(Character.class);
+                            }
                             else {
                                 paramList.add(getParamValue(requestParamVal, defaultValue));
                                 classList.add(String.class);

--- a/framework/framework-netty/src/test/java/io/edurt/gcm/netty/controller/TestRequestController.java
+++ b/framework/framework-netty/src/test/java/io/edurt/gcm/netty/controller/TestRequestController.java
@@ -20,6 +20,8 @@ import io.edurt.gcm.netty.annotation.RestController;
 import io.edurt.gcm.netty.model.TestModel;
 import io.edurt.gcm.netty.type.RequestMethod;
 
+import java.util.HashMap;
+
 @RequestMapping(value = {"/query", "/query/v1"})
 @RestController
 public class TestRequestController
@@ -34,5 +36,20 @@ public class TestRequestController
     public Object put(@RequestBody TestModel value)
     {
         return value;
+    }
+
+    @RequestMapping(value = "home/params", method = RequestMethod.GET)
+    public Object get(
+            @RequestParam(value = "bool") Boolean boolParam,
+            @RequestParam(value = "char") Character charParam,
+            @RequestParam(value = "float") Float floatParam,
+            @RequestParam(value = "double") Double doubleParam)
+    {
+        HashMap<String, Object> ret = new HashMap<>();
+        ret.put("bool", boolParam);
+        ret.put("char", charParam);
+        ret.put("float", floatParam);
+        ret.put("double", doubleParam);
+        return ret;
     }
 }


### PR DESCRIPTION
**Changelog category (leave one)**

- New Feature

**Changelog entry (Details of this change)**
Supported parsing Double, Float, Boolean, Character type of request parameter. Related issue:
> [issue-39](https://github.com/EdurtIO/incubator-gcm/issues/39)

**Affected version**
- 1.3.0-SNAPSHOT
